### PR TITLE
[refactor] Q 클래스 생성 위치 관련 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,6 @@ application.yml
 
 ### QueryDSL ###
 /build/generated/
+/src/main/generated/
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -79,13 +79,17 @@ tasks.named('test') {
     useJUnitPlatform()
 }
 
-def querydslDir = "build/generated"
+def querydslDir = "$buildDir/generated/querydsl"
 
 sourceSets {
-    main.java.srcDirs += querydslDir
+    main {
+        java {
+            srcDirs += querydslDir
+        }
+    }
 }
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
     options.compilerArgs << "-parameters"
     options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #39 

## 📝 작업 내용

> QueryDSL 생성 위치 build/generated/querydsl로 고정 후 src쪽에 안들어가도록 .gitignore 설정 추가 

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요