### PR TITLE
[refactor] 채용공고에 기반한 AI 키워드 추출 Redis Cache 사용하여 성능 개선 진행

### DIFF
--- a/src/main/java/com/server/ServerApplication.java
+++ b/src/main/java/com/server/ServerApplication.java
@@ -2,11 +2,13 @@ package com.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 
 @SpringBootApplication
 @EnableScheduling
+@EnableCaching
 public class ServerApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/server/ai/service/KeywordExtractorService.java
+++ b/src/main/java/com/server/ai/service/KeywordExtractorService.java
@@ -3,6 +3,7 @@ package com.server.ai.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -17,6 +18,7 @@ public class KeywordExtractorService {
     private final ChatClient chatClient;
 
     // 채용공고에서 AI를 통해 주요 키워드(기술, 자격증 등) 추출
+    @Cacheable(value = "ai_keywords", key = "#jdDescription") // 성능 개선을 위한 Redis Cache 적용
     public List<String> extractKeywords(String jdDescription) {
         String prompt = """
             아래 채용 공고 설명에서 관련 기술 스택, 자격증, 사용 언어, 프레임워크, 도구 등을 키워드로 추출해줘.


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #131 

## 📝 작업 내용

> JD 설명 기반 이력서 추천 API의 성능 개선을 위해 AI 기반 키워드 추출 로직에 Redis 캐시 적용


1. @Cacheable을 활용하여 JD 설명 기반 키워드 추출 결과를 Redis에 저장
2. 동일한 JD 설명에 대해 AI 키워드 추출 로직을 한 번만 호출하도록 최적화
3. @EnableCaching 설정 추가하여 Spring Cache 활성화

## 🖼️ 스크린샷 (선택)
### Redis Cache 적용 전 (API 응답 시간 1231.13ms)
<img width="1773" height="119" alt="1차성능측정" src="https://github.com/user-attachments/assets/270de5d6-cbc8-41f3-8d44-b8c232aa7b31" />

### Redis Cache 적용 후 (API 응답 시간 74.3ms)
<img width="1647" height="69" alt="화면 캡처 2025-11-26 161019" src="https://github.com/user-attachments/assets/c0d9a901-ec8c-444d-8d58-ecbd47150582" />


```
2025-11-26T16:09:15.234+09:00  INFO 6908 --- [jobda-server] [    Test worker] com.server.global.aop.LoggingAspect      : [ END ] com.server.match.service.MatchService.recommendResumes()
2025-11-26T16:09:15.238+09:00  INFO 6908 --- [jobda-server] [    Test worker] c.server.global.aop.ExecutionTimeLogger  : [API 실행 시간] 32ms - com.server.match.controller.MatchController.recommendResumes
평균 추천 API 응답 시간: 74.3ms
```

**결론 => API 응답 시간 16배 이상 개선, 74.3ms는 우수한 수준으로 성능 문제 해결 완료.**

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요