### PR TITLE
[feat] 지원서 작성 시 공고에 지원자 수 증가하도록  구현

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -72,7 +72,7 @@ services:
       - xpack.security.enabled=false
       - ES_JAVA_OPTS=-Xms512m -Xmx512m
     ports:
-      - "19200:9200"
+      - "9200:9200"
       - "9300:9300"
     volumes:
       - esdata:/usr/share/elasticsearch/data


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #184 

## 📝 작업 내용

> 공고에 지원 시 (/resume/create/{id}에서 지원서 생성) 공고에 지원자 수가 생성되도록 구현 
추가적인 메서드 구현은 아니고 매치 시에 지원자 수도 증가하도록 기능 하나 추가

## 🖼️ 스크린샷 (선택)

> 
<img width="998" height="229" alt="image" src="https://github.com/user-attachments/assets/247db8de-22aa-41a7-89b2-bf59aed94936" />


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요