### PR TITLE
[release] CI/CD 배포용 docker compose 이미지 태그 버전 자동 할당되도록 변경

### DIFF
--- a/docker-compose-cd.yml
+++ b/docker-compose-cd.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/${OWNER_NAME}/jobda-app:prod
+    image: ghcr.io/${OWNER_NAME}/jobda-app:${IMAGE_TAG}
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

> 이미지 오래된 버전으로 인한 디스크 용량 문제로 CI쪽 태그 사용하도록 변경 

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요