### PR TITLE
[fix] Redis 추천 캐시 역직렬화 시 LinkedHashMap 캐스팅 오류 수정

### DIFF
--- a/src/main/java/com/server/global/config/JacksonConfig.java
+++ b/src/main/java/com/server/global/config/JacksonConfig.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Configuration
 public class JacksonConfig {
@@ -14,5 +15,13 @@ public class JacksonConfig {
         return builder -> builder
                 .modules(new JavaTimeModule())
                 .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return mapper;
     }
 }

--- a/src/main/java/com/server/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/server/global/config/security/SecurityConfig.java
@@ -75,7 +75,7 @@ public class SecurityConfig {
                                 "/api/v1/notifications/**",
                                 "/api/v1/files/**"
                         ).permitAll()
-                        
+
                         .requestMatchers("/api/v1/users/me").authenticated()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/server/match/cache/RedisRecommendationCacheService.java
+++ b/src/main/java/com/server/match/cache/RedisRecommendationCacheService.java
@@ -1,10 +1,13 @@
 package com.server.match.cache;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.server.ai.service.AiRecommendationService;
 import com.server.ai.service.KeywordExtractorService;
 import com.server.match.util.RecommendationReasonBuilder;
 import com.server.search.document.ResumeDocument;
 import com.server.search.domain.JdKeyword;
+import com.server.search.dto.ResumeRecommendationDto;
 import com.server.search.repository.JdKeywordRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +27,7 @@ public class RedisRecommendationCacheService {
     private final KeywordExtractorService keywordExtractorService;
     private final AiRecommendationService aiRecommendationService;
     private final JdKeywordRepository jdKeywordRepository;
+    private final ObjectMapper objectMapper;
     private static final Duration TTL = Duration.ofDays(30);
 
     public boolean existsRecommendationFor(Long jdId) {
@@ -35,8 +39,15 @@ public class RedisRecommendationCacheService {
     }
 
     @SuppressWarnings("unchecked")
-    public <T> T getRecommendations(Long jdId) {
-        return (T) redisTemplate.opsForValue().get("recommend:jd_" + jdId);
+    public List<ResumeRecommendationDto> getRecommendations(Long jdId) {
+        Object raw = redisTemplate.opsForValue().get("recommend:jd_" + jdId);
+
+        if (raw == null) return null;
+
+        return objectMapper.convertValue(
+                raw,
+                new TypeReference<List<ResumeRecommendationDto>>() {}
+        );
     }
 
     // JD 설명 기반 키워드 캐시 조회 또는 생성


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #158 

## 📝 작업 내용

RedisTemplate 저장 형식 때문에 추천 목록 조회 시 
LinkedHashMap cannot be cast to ResumeRecommendationDto 예외가 발생하던 문제 관련 수정 진행 

- ObjectMapper 기반 역직렬화 추가
- 캐시 데이터를 List<ResumeRecommendationDto>로 변환하도록 변경
- JacksonConfig에 ObjectMapper 자동 주입 추가로 JSON 역직렬화 보장

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요