### PR TITLE
[fix] 블루/그린 docker 헬스체크 포트 8080으로 변경

### DIFF
--- a/docker-compose-blue.yml
+++ b/docker-compose-blue.yml
@@ -17,7 +17,7 @@ services:
     depends_on:
       - redis
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8081/actuator/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       interval: 10s
       timeout: 3s
       retries: 5

--- a/docker-compose-green.yml
+++ b/docker-compose-green.yml
@@ -17,7 +17,7 @@ services:
     depends_on:
       - redis
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8081/actuator/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       interval: 10s
       timeout: 3s
       retries: 5


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #268 

## 📝 작업 내용

> green 컨테이너에서 Redis 헬스체크 실패로 인한 배포 실패로 헬스체크 관련 포트 변경 

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요