### PR TITLE
[fix] 지원자 조회에서 이력서 프로필 이미지 정상 표시되도록 수정

### DIFF
--- a/src/main/java/com/server/match/repository/MatchQueryRepositoryImpl.java
+++ b/src/main/java/com/server/match/repository/MatchQueryRepositoryImpl.java
@@ -13,6 +13,7 @@ import com.server.match.dto.MatchSearchCondition;
 import com.server.match.util.MatchScoreCalculator;
 import com.server.resume.domain.QResume;
 import com.server.resume.domain.Resume;
+import com.server.s3.service.PresignedUrlProvider;
 import com.server.search.document.ResumeDocument;
 import com.server.search.service.ResumeSearchService;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +31,7 @@ public class MatchQueryRepositoryImpl implements MatchQueryRepository {
     private final ResumeSearchService resumeSearchService;
     private final KeywordExtractorService keywordExtractorService;
     private final AiRecommendationService aiRecommendationService;
+    private final PresignedUrlProvider presignedUrlProvider;
 
     @Override
     public Page<MatchListResponseDto> searchMatches(MatchSearchCondition condition, Pageable pageable) {
@@ -83,10 +85,18 @@ public class MatchQueryRepositoryImpl implements MatchQueryRepository {
                 summary = aiRecommendationService.generateResumeSummary(doc.getFullText());
             }
 
+            String profileImageUrl = null;
+            if (resumeEntity.getResumeFileUrl() != null) {
+                profileImageUrl =
+                        presignedUrlProvider.createPresignedGetUrl(
+                                resumeEntity.getResumeFileUrl()
+                        );
+            }
+
             return new MatchListResponseDto(
                     resumeEntity.getId(),
                     resumeEntity.getName(),
-                    resumeEntity.getPortfolioFileUrl(),
+                    profileImageUrl,
                     m.getMatchScore(),
                     m.getStatus(),
                     matchRate,


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #306 

## 📝 작업 내용

> 이력서의 프로필 사진을 presigned URL로 변환하여 응답하도록 개선
> 매치 리스트에서는 포트폴리오 파일을 제외하고 프로필 이미지 정보만 내려주도록 DTO 매핑 정리

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요