### PR TITLE
[fix] S3 키인 경우만 presigned URL 생성하도록 로직 수정

### DIFF
--- a/src/main/java/com/server/match/repository/MatchQueryRepositoryImpl.java
+++ b/src/main/java/com/server/match/repository/MatchQueryRepositoryImpl.java
@@ -86,11 +86,15 @@ public class MatchQueryRepositoryImpl implements MatchQueryRepository {
             }
 
             String profileImageUrl = null;
-            if (resumeEntity.getResumeFileUrl() != null) {
-                profileImageUrl =
-                        presignedUrlProvider.createPresignedGetUrl(
-                                resumeEntity.getResumeFileUrl()
-                        );
+            String resumeFileUrl = resumeEntity.getResumeFileUrl();
+
+            if (resumeFileUrl != null) {
+                if (resumeFileUrl.startsWith("http")) {
+                    profileImageUrl = resumeFileUrl;
+                } else {
+                    profileImageUrl =
+                            presignedUrlProvider.createPresignedGetUrl(resumeFileUrl);
+                }
             }
 
             return new MatchListResponseDto(

--- a/src/main/java/com/server/match/service/RecommendationCoreService.java
+++ b/src/main/java/com/server/match/service/RecommendationCoreService.java
@@ -123,11 +123,12 @@ public class RecommendationCoreService {
                     }
 
                     String profileImageUrl = null;
-                    if (resume.getResumeFileUrl() != null) {
-                        profileImageUrl =
-                                presignedUrlProvider.createPresignedGetUrl(
-                                        resume.getResumeFileUrl()
-                                );
+                    String resumeFileUrl = resume.getResumeFileUrl();
+
+                    if (resumeFileUrl != null) {
+                        profileImageUrl = resumeFileUrl.startsWith("http")
+                                ? resumeFileUrl
+                                : presignedUrlProvider.createPresignedGetUrl(resumeFileUrl);
                     }
 
                     ResumeRecommendationDto dto = ResumeRecommendationDto.from(


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #308 

## 📝 작업 내용

- S3 key
- 외부 URL
- 예전 방식 데이터 (URL)
=> 허용하고 아닌 경우 (S3 키인 경우만 presigned URL 생성) 하도록 변경 

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요