### PR TITLE
[refactor] 지원자 추천 시스템 정렬 방식 점수 높은순이 default가 되도록 로직 변경

### DIFF
--- a/src/main/java/com/server/match/service/MatchService.java
+++ b/src/main/java/com/server/match/service/MatchService.java
@@ -8,6 +8,7 @@ import com.server.jd.repository.JobDescriptionRepository;
 import com.server.match.async.RecommendationAsyncService;
 import com.server.match.cache.RedisRecommendationCacheService;
 import com.server.match.domain.Match;
+import com.server.match.domain.MatchSortType;
 import com.server.match.domain.MatchStatus;
 import com.server.match.dto.*;
 import com.server.match.exception.MatchErrorCase;
@@ -92,16 +93,25 @@ public class MatchService {
                 .limit(limit)
                 .toList();
         
-        //정렬
-        if(sortType.equals("LATEST")) {
-            return limitedList.stream()
+        // 정렬 (점수 높은순 default)
+        MatchSortType resolvedSortType;
+        try {
+            resolvedSortType = MatchSortType.valueOf(
+                    sortType != null ? sortType : MatchSortType.SCORE_DESC.name()
+            );
+        } catch (IllegalArgumentException e) {
+            resolvedSortType = MatchSortType.SCORE_DESC;
+        }
+
+        return switch (resolvedSortType) {
+            case LATEST -> limitedList.stream()
                     .sorted(Comparator.comparing(ResumeRecommendationDto::resumeCreateTime).reversed())
                     .toList();
-        } else {
-            return limitedList.stream()
+
+            case SCORE_DESC -> limitedList.stream()
                     .sorted(Comparator.comparing(ResumeRecommendationDto::matchScore).reversed())
                     .toList();
-        }
+        };
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> X

## 📝 작업 내용

> 지원자 추천 조회 시스템에서 최신순으로 default가 되어있는 로직을 점수 (추천 매칭률) 이 높은순이 default가 되도록 로직 개선 

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요