### PR TITLE
[refactor] Prometheus 메트릭 수집 대상 안정화

### DIFF
--- a/prometheus.yml
+++ b/prometheus.yml
@@ -5,4 +5,4 @@ scrape_configs:
   - job_name: 'spring-boot'
     metrics_path: '/actuator/prometheus'
     static_configs:
-      - targets: ['jobda-app:8081']
+      - targets: ['10.0.100.115:8081']


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #233 

## 📝 작업 내용
> Docker 컨테이너 DNS(jobda-app) 대신 EC2 내부 IP를 타겟으로 변경
> 메트릭 수집이 끊기지 않도록 구성 안정화

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요